### PR TITLE
[PR]#최도혁#-#1068#

### DIFF
--- a/src/main/java/최도혁/주차10/BOJ_1068/Main.java
+++ b/src/main/java/최도혁/주차10/BOJ_1068/Main.java
@@ -1,0 +1,75 @@
+package 최도혁.주차10.BOJ_1068;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class Main {
+
+    private static final Map<Integer, List<Integer>> tree = new HashMap<>();
+    private static int cnt = 0;
+    private static int root;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        int N = Integer.parseInt(br.readLine());
+        String[] parents = br.readLine().split(" ");
+
+        for (int i = 0; i < N; i++) {
+            int parent = Integer.parseInt(parents[i]);
+
+            if (parent == -1) {
+                root = i;  // 루트 노드 설정
+                continue;
+            }
+
+            tree.putIfAbsent(parent, new ArrayList<>());
+            tree.get(parent).add(i);
+        }
+
+        int delIndex = Integer.parseInt(br.readLine());
+
+        deleteNode(delIndex);
+
+        // 루트가 삭제되지 않은 경우에만 리프 노드 계산
+        if (delIndex != root) {
+            countLeafNodes(root);
+        }
+
+        System.out.print(cnt);
+    }
+
+    private static void countLeafNodes(int node) {
+        if (!tree.containsKey(node) || tree.get(node).isEmpty()) {
+            cnt++;
+            return;
+        }
+
+        for (int child : tree.get(node)) {
+            countLeafNodes(child);
+        }
+    }
+
+    private static void deleteNode(int node) {
+        // 노드를 삭제하기 위해 큐 사용 (BFS 방식)
+        Queue<Integer> toDelete = new LinkedList<>();
+        toDelete.add(node);
+
+        while (!toDelete.isEmpty()) {
+            int current = toDelete.poll();
+
+            // 현재 노드에 자식이 있으면, 삭제할 노드 큐에 추가
+            if (tree.containsKey(current)) {
+                toDelete.addAll(tree.get(current));
+                tree.remove(current);  // 현재 노드를 트리에서 제거
+            }
+        }
+
+        // 부모 노드에서 삭제된 노드에 대한 참조 제거
+        for (int parent : tree.keySet()) {
+            tree.get(parent).remove(Integer.valueOf(node));
+        }
+    }
+}


### PR DESCRIPTION
TreeMap을 기본으로 사용
노드 삭제 시 노드 순환과 수정이 동시에 일어나서 ConcurrentModificationException 이 발생했었음
해결방안으로 삭제할 노드를 Queue에 저장해두고 순환 후 삭제로 변경

[수정 전 코드]
for(int key : tree.keySet()){
            List<Integer> child = tree.get(key);

            if(child.contains(node)){
                int idx = child.indexOf(node);
                tree.get(key).remove(idx);
                if(tree.get(key).isEmpty()) tree.remove(key); -> ConcurrentModificationException 발생
            }
}

-결론-
TreeMap 자료구조 및 BFS 방식 사용